### PR TITLE
feat:升级fastjson,401时添加 WWW-Authenticate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <disruptor.version>3.3.6</disruptor.version>
         <!-- spring -->
         <spring.version>4.3.3.RELEASE</spring.version>
-        <fastjson.version>1.2.18</fastjson.version>
+        <fastjson.version>1.2.31</fastjson.version>
         <apache.common.lang3.version>3.4</apache.common.lang3.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <apache.common.io.version>2.5</apache.common.io.version>

--- a/summer-core/src/main/java/org/smartx/summer/filter/JwtTokenAuthFilter.java
+++ b/summer-core/src/main/java/org/smartx/summer/filter/JwtTokenAuthFilter.java
@@ -91,8 +91,11 @@ public class JwtTokenAuthFilter extends OncePerRequestFilter {
         }
     }
 
+
     public void convertMsgToJson(HttpServletResponse response, String errMsg) throws IOException {
         State errorResponse = new State(HttpStatus.UNAUTHORIZED.value(), errMsg);
+        //支持低端android 设备，防止 java.io.IOException : No authentication challenges found
+        response.setHeader("WWW-Authenticate", "xBasic realm=\"fake\"");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.getWriter().print(JSON.toJSON(errorResponse));
     }

--- a/summer-core/src/main/java/org/smartx/summer/interceptor/JwtInterceptor.java
+++ b/summer-core/src/main/java/org/smartx/summer/interceptor/JwtInterceptor.java
@@ -59,8 +59,10 @@ public class JwtInterceptor extends HandlerInterceptorAdapter {
                     request.setAttribute(SessionAndTokenConstants.SESSION_USER_ID, userId);
                     request.setAttribute(SessionAndTokenConstants.TOKEN_CLAIMS, claims);
                 } catch (SignatureException exception) {
+                    response.setHeader("WWW-Authenticate", "xBasic realm=\"fake\"");
                     throw new AuthenticationException(TokenProvider.TOKEN_INVALID_SIGNATURE);
                 } catch (final Exception e) {
+                    response.setHeader("WWW-Authenticate", "xBasic realm=\"fake\"");
                     throw new AuthenticationException(TokenProvider.DEFAULT_INVALID_JWT_MSG);
                 }
             } else {


### PR DESCRIPTION
* 升级fastjson 为最新版本
* 返回401 状态码时，添加header  WWW-Authenticate,以兼容低端android 设备